### PR TITLE
20 test pip cache for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - 3.5
   - 3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ NuMPI>=0.1.1
 pytest>=4
 pytest-flake8
 setuptools_scm>=3.5.0
-muFFT>=0.9.1
+muFFT>=0.9.3
 runtests>=0.0.28

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     install_requires=[
         'numpy>=1.11.0',
         'NuMPI>=0.1.1',
-        'muFFT>=0.9.1',
+        'muFFT>=0.9.3',
         'netCDF4>=1.5.0',
         'igor',
         'h5py',


### PR DESCRIPTION
I've tested the setting
```
cache: pip
```
in `.travis.yaml`. The builds are roughly 2 minutes faster than without, because 20 packages, which were already downloaded
are reused.

Is this a good idea or does anybody have reservations regarding this?