### PR TITLE
BUG: the imaginary part of the fourier_derivative should be small in a relative sense, not absolute

### DIFF
--- a/SurfaceTopography/Uniform/common.py
+++ b/SurfaceTopography/Uniform/common.py
@@ -147,8 +147,10 @@ def fourier_derivative(topography, imtol=None):
     dy = np.fft.ifft2(spectrum * (1j * qy))
 
     if imtol is not None:
-        assert (abs(dx.imag) / np.mean(abs(dx)) < imtol).all(), np.max(abs(dx.imag) / np.mean(abs(dx)))
-        assert (abs(dy.imag) / np.mean(abs(dy)) < imtol).all(), np.max(abs(dy.imag) / np.mean(abs(dy)))
+        assert (abs(dx.imag) / np.mean(abs(dx)) < imtol).all(), \
+            np.max(abs(dx.imag) / np.mean(abs(dx)))
+        assert (abs(dy.imag) / np.mean(abs(dy)) < imtol).all(), \
+            np.max(abs(dy.imag) / np.mean(abs(dy)))
 
     dx = dx.real
     dy = dy.real

--- a/SurfaceTopography/Uniform/common.py
+++ b/SurfaceTopography/Uniform/common.py
@@ -96,7 +96,7 @@ def derivative(topography, n, periodic=None):
         return der
 
 
-def fourier_derivative(topography, imtol=1e-12):
+def fourier_derivative(topography, imtol=None):
     r"""
 
     First order derivatives of the fourier interpolation of the Topography
@@ -119,11 +119,11 @@ def fourier_derivative(topography, imtol=1e-12):
     Parameters
     ----------
     topography: Topography instance
-    imtol: float
+    imtol: float, optional
         tolerance for the discarded imaginary part. If the maximum absolute of
         the imaginary part of the interpolated topography is more then that
         value times the total absolute value of dx, an AssertionError is raised
-
+        If not specified the assertion will not be made.
     Returns
     -------
     dx: array of floats
@@ -146,8 +146,9 @@ def fourier_derivative(topography, imtol=1e-12):
     dx = np.fft.ifft2(spectrum * (1j * qx))
     dy = np.fft.ifft2(spectrum * (1j * qy))
 
-    assert (abs(dx.imag) / abs(dx) < imtol).all(), np.max(abs(dx.imag))
-    assert (abs(dy.imag) / abs(dy) < imtol).all(), np.max(abs(dy.imag))
+    if imtol is not None:
+        assert (abs(dx.imag) / np.mean(abs(dx)) < imtol).all(), np.max(abs(dx.imag) / np.mean(abs(dx)))
+        assert (abs(dy.imag) / np.mean(abs(dy)) < imtol).all(), np.max(abs(dy.imag) / np.mean(abs(dy)))
 
     dx = dx.real
     dy = dy.real

--- a/SurfaceTopography/Uniform/common.py
+++ b/SurfaceTopography/Uniform/common.py
@@ -122,7 +122,7 @@ def fourier_derivative(topography, imtol=1e-12):
     imtol: float
         tolerance for the discarded imaginary part. If the maximum absolute of
         the imaginary part of the interpolated topography is more then that
-        value, an AssertionError is raised
+        value times the total absolute value of dx, an AssertionError is raised
 
     Returns
     -------
@@ -146,8 +146,8 @@ def fourier_derivative(topography, imtol=1e-12):
     dx = np.fft.ifft2(spectrum * (1j * qx))
     dy = np.fft.ifft2(spectrum * (1j * qy))
 
-    assert (abs(dx.imag) < imtol).all(), np.max(abs(dx.imag))
-    assert (abs(dy.imag) < imtol).all(), np.max(abs(dy.imag))
+    assert (abs(dx.imag) / abs(dx) < imtol).all(), np.max(abs(dx.imag))
+    assert (abs(dy.imag) / abs(dy) < imtol).all(), np.max(abs(dy.imag))
 
     dx = dx.real
     dy = dy.real

--- a/test/test_topography1.py
+++ b/test/test_topography1.py
@@ -1168,7 +1168,7 @@ def test_fourier_derivative_realness(nx, ny):
     # configuration of odd and even grid points
     topography = Topography(np.random.random((nx, ny)),
                             physical_sizes=(2., 3.))
-    topography.fourier_derivative()
+    topography.fourier_derivative(imtol=1e-12)
 
 
 def test_fourier_derivative(plot=False):
@@ -1181,7 +1181,7 @@ def test_fourier_derivative(plot=False):
     topography = topography.scale(1 / topography.rms_height())
 
     # numerical derivatives to double check
-    dx, dy = topography.fourier_derivative()
+    dx, dy = topography.fourier_derivative(imtol=1e-12)
     dx_num, dy_num = topography.derivative(1)
 
     np.testing.assert_allclose(dx, dx_num, atol=topography.rms_slope() * 1e-1)


### PR DESCRIPTION
I also think that we should actually remove these assertion (see commit), it was introduced for testing/debugging purposes only. 

For big systems the tolerance need to be increased and it is will be annoying to increase manually the tolerance.

What do you thlink @pastewka  ?  