### PR TITLE
BUG: Same versions in setup.py and requirements.

### DIFF
--- a/SurfaceTopography/ChangeLog.md
+++ b/SurfaceTopography/ChangeLog.md
@@ -2,6 +2,11 @@
 Change log for SurfaceTopography
 =============================
 
+v0.91.5 (19Oct20)
+-----------------
+
+- BUG: Fixed differing versions in setup.py and requirements
+
 v0.91.4 (16Oct20)
 -----------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ NuMPI>=0.1.4
 pytest>=4
 pytest-flake8
 setuptools_scm>=3.5.0
-muFFT>=0.10.0
+muFFT>=0.11.1
 runtests>=0.0.28

--- a/setup.py
+++ b/setup.py
@@ -132,8 +132,8 @@ setup(
     ],
     install_requires=[
         'numpy>=1.11.0',
-        'NuMPI>=0.1.1',
-        'muFFT>=0.10.0',
+        'NuMPI>=0.1.4',
+        'muFFT>=0.11.1',
         'netCDF4>=1.5.0',
         'igor',
         'h5py',


### PR DESCRIPTION
I need a new version for TopoBank with same versions for NuMPI in setup.py and requirements.