### PR TITLE
MAINT: Changed default NetCDF format to NETCDF3_64BIT_OFFSET, fixes #48

### DIFF
--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -178,7 +178,7 @@ plt.show()
     topography.__doc__ = ReaderBase.topography.__doc__
 
 
-def write_nc(topography, filename, format='NETCDF4'):
+def write_nc(topography, filename, format='NETCDF3_64BIT_OFFSET'):
     """
     Write topography into a NetCDF file.
 
@@ -189,7 +189,7 @@ def write_nc(topography, filename, format='NETCDF4'):
     filename : str
         Name of the NetCDF file
     format : str
-        NetCDF file format. Default is 'NETCDF4'.
+        NetCDF file format. Default is 'NETCDF3_64BIT_OFFSET'.
     """
     from netCDF4 import Dataset
     if not topography.is_domain_decomposed and \

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -178,7 +178,7 @@ plt.show()
     topography.__doc__ = ReaderBase.topography.__doc__
 
 
-def write_nc(topography, filename, format='NETCDF3_64BIT_DATA'):
+MAIdef write_nc(topography, filename, format='NETCDF4'):
     """
     Write topography into a NetCDF file.
 

--- a/SurfaceTopography/IO/NC.py
+++ b/SurfaceTopography/IO/NC.py
@@ -178,7 +178,7 @@ plt.show()
     topography.__doc__ = ReaderBase.topography.__doc__
 
 
-MAIdef write_nc(topography, filename, format='NETCDF4'):
+def write_nc(topography, filename, format='NETCDF4'):
     """
     Write topography into a NetCDF file.
 


### PR DESCRIPTION
I suggest we change the default behavior to NETCDF4. I am bit unhappy, because this is the monstrous HDF5 format, but this is the only current solution that allows large topographies (32k x 32k and bigger) and support for MATLAB.